### PR TITLE
Use .toLocaleTimeString() instead of constructing the time

### DIFF
--- a/plugins/time/time.js
+++ b/plugins/time/time.js
@@ -3,6 +3,6 @@ function time() {
 
     setInterval(function() {
         var time = new Date;
-        $('#time .time_now').text(time.getHours() + ":"  + time.getMinutes() + ":" + time.getSeconds() );
+        $('#time .time_now').text(time.toLocaleTimeString());
     }, 1000);
 }


### PR DESCRIPTION
Time without leading zeroes looks weird to me ("12:8:1"), `.toLocaleTimeString()` does the right formatting automatically and probably works better for other languages too.
